### PR TITLE
fix warning: cast from pointer to integer of different size

### DIFF
--- a/include/m4a.h
+++ b/include/m4a.h
@@ -399,7 +399,7 @@ enum
 extern char gNumMusicPlayers[];
 extern char gMaxLines[];
 
-#define NUM_MUSIC_PLAYERS ((u16) gNumMusicPlayers)
+#define NUM_MUSIC_PLAYERS ((u16)(u32) gNumMusicPlayers)
 #define MAX_LINES ((u32) gMaxLines)
 
 // end TODO


### PR DESCRIPTION
warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
```
#define NUM_MUSIC_PLAYERS ((u16) gNumMusicPlayers)
```